### PR TITLE
Update ng-repeat field so mentor tags display on mentors page.

### DIFF
--- a/views/index/mentors.twig
+++ b/views/index/mentors.twig
@@ -22,7 +22,7 @@
                         <img src="{% verbatim %}{{ mentor.imageUrl }}{% endverbatim %}?s=150" width="150" height="150"/>
 
                         <div class="tags">
-                            <span class="label label-primary" data-ng-repeat="tag in mentor.apprenticeTags">
+                            <span class="label label-primary" data-ng-repeat="tag in mentor.mentorTags">
                                 {% verbatim %}{{ tag.name }}{% endverbatim %}
                             </span>
                         </div>


### PR DESCRIPTION
Fixes issue where Apprentice tags appear on user profiles on Mentors page.
