### PR TITLE
Make profile tags use list markup

### DIFF
--- a/views/index/profile.twig
+++ b/views/index/profile.twig
@@ -18,9 +18,13 @@
         {% if viewing_user.isMentee %}
         <strong>Apprentice</strong>
         <div class="tags">
+            <ul class="list-inline">
             {% for tag in viewing_user.apprenticeTags %}
-            <span class="label label-primary">
-                {{ tag.name }}
+                <li>
+                    <span class="label label-primary">
+                        {{ tag.name }}
+                    </span>
+                </li>
             </span>
             {% endfor %}
         </div>


### PR DESCRIPTION
Profile tags: now with improved semantic markup usage and column wrapping!

Before:

<img width="676" alt="screen_shot_2015-08-02_at_3_38_03_pm" src="https://cloud.githubusercontent.com/assets/15487/9027924/2622c572-392d-11e5-88a3-497dd671c8c1.png">

After:

<img width="678" alt="screen_shot_2015-08-02_at_3_43_23_pm" src="https://cloud.githubusercontent.com/assets/15487/9027934/528fc196-392d-11e5-801a-487fce266138.png">
