### PR TITLE
Allow user to search for mentor with multiple tags separated by comma.

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -29,10 +29,16 @@ mentoringApp.filter('mentorTags', function() {
             }
 
             tags = tags.toLowerCase();
+            tags = tags.split(",");
             for(var i in mentor.mentorTags) {
                 var name = mentor.mentorTags[i].name.toLowerCase();
-                if(name.indexOf(tags) > -1) {
-                    return true;
+
+                for(var x = 0; x < tags.length; x++) {
+                    var tag = tags[x].trim();
+
+                    if(name.indexOf(tag) > -1 && tag != "") {
+                        return true;
+                    }
                 }
             }
 

--- a/views/index/mentors.twig
+++ b/views/index/mentors.twig
@@ -3,7 +3,7 @@
     <h1>PHP Mentors</h1>
 
     <div data-ng-controller="MentorSearchController">
-        <p>Type in a tag to search for a mentor. Right now this only supports one tag.</p>
+        <p>Type in a tag to search for a mentor. Separate tags with comma (e.g. PHP, testing).</p>
         <form>
             <div class="input-group">
                 <label for="name">Subject:</label> <input type="text" name="name" data-ng-model="name">


### PR DESCRIPTION
For issue #48.
This allows the user to search for a mentor with multiple tags using a comma as a delimiter. By default the search uses OR. So if one of the ten tags the user is searching by exists on the mentor the mentor will display on the results.
