### PR TITLE
a migration that enables notifications for all accounts

### DIFF
--- a/data/migrations/20150822164501_enable_notifications_one_time.php
+++ b/data/migrations/20150822164501_enable_notifications_one_time.php
@@ -1,0 +1,35 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class EnableNotificationsOneTime extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     *
+     * Uncomment this method if you would like to use it.
+     *
+    public function change()
+    {
+    }
+    */
+
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->execute('UPDATE users SET sendNotifications = 1');
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+
+    }
+}


### PR DESCRIPTION
related to #43 

From that issue:
"I've made it such that new registrations will have notifications turned on by default .However there are dozens of accounts on the site already, and it's likely many of them didn't get a chance to see the setting. I think we should do a one-time DB update to turn notifications to "on" for everyone, and they can login to opt out if necessary. I think overall most poeple will want this enabled anyway. I'll make a PR and we can discuss it."
