### PR TITLE
Fetches GitHub-Username for easier info-retrieval

### DIFF
--- a/app/console
+++ b/app/console
@@ -1,0 +1,16 @@
+#!/usr/bin/env php
+<?php
+
+// set to run indefinitely if needed
+set_time_limit(0);
+
+// include the composer autoloader
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// import the Symfony Console Application
+use Symfony\Component\Console\Application;
+use Mentoring\Command\AddMissingGithubUsernamesCommand;
+
+$app = new Application();
+$app->add(new AddMissingGithubUsernamesCommand());
+$app->run();

--- a/data/migrations/20150915143127_add_github_username.php
+++ b/data/migrations/20150915143127_add_github_username.php
@@ -1,0 +1,40 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddGithubUsername extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     *
+     * Uncomment this method if you would like to use it.
+     *
+    public function change()
+    {
+    }
+    */
+    
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $users = $this->table('users');
+
+        $users->addColumn('githubName', 'text', ['null' => true])->update();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $users = $this->table('users');
+
+        $users->removeColumn('githubName');
+
+    }
+}

--- a/src/Mentoring/Command/AddMissingGithubUsernamesCommand.php
+++ b/src/Mentoring/Command/AddMissingGithubUsernamesCommand.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Mentoring\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AddMissingGithubUsernamesCommand extends Command
+{
+    protected function configure()
+    {
+        $this->setName("mentoring:addMissingGithubUsernames")
+             ->setDescription("Add missing github-Usernames")
+             ->setHelp(<<<EOT
+Add missing github-Usernames based on the github-UserID
+EOT
+             );
+    }
+
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Starting to fetch github-Usernames');
+        $data = parse_ini_file(__DIR__ . '/../../../.env');
+        $pdo = new \PDO(
+            'mysql:dbname=' . $data['DB_DBNAME'] . ';host=' . $data['DB_HOSTNAME'],
+            $data['DB_USERNAME'],
+            $data['DB_PASSWORD']
+        );
+
+        $select = $pdo->prepare('SELECT * FROM `users` WHERE `githubName` = ""');
+
+        $update = $pdo->prepare('UPDATE `users` SET `githubName`= :githubName WHERE githubUid = :githubUid');
+
+        $select->execute();
+        $result = $select->fetchAll();
+
+        foreach ($result as $row) {
+            $output->writeln(sprintf(
+                'Fetching username for user %s (%s)',
+                $row['githubUid'],
+                $row['name']
+            ));
+
+            $ch = curl_init('https://api.github.com/users?per_page=1&since=' . ($row['githubUid'] - 1));//Here is the file we are downloading, replace spaces with %20
+            curl_setopt($ch, CURLOPT_TIMEOUT, 2);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+//                sprintf('Authorization: token %s', $data['GITHUB_API_KEY']),
+                'User-Agent: PHPMentoring-App',
+            ));
+            $info = curl_exec($ch); // get curl response
+            curl_close($ch);
+
+            var_Dump($info);
+            $info = json_decode($info, true);
+
+            var_Dump($info);
+            if (! isset($info[0])) {
+                throw new \Exception('Transport Error occured');
+            }
+
+            $update->execute(array(
+                ':githubUid' => $row['githubUid'],
+                ':githubName' => $info[0]['login'],
+            ));
+        }
+
+        $output->writeln('Finished');
+    }
+}

--- a/src/Mentoring/Command/AddMissingGithubUsernamesCommand.php
+++ b/src/Mentoring/Command/AddMissingGithubUsernamesCommand.php
@@ -50,12 +50,14 @@ EOT
                 $row['name']
             ));
 
-            $ch = curl_init('https://api.github.com/users?per_page=1&since=' . ($row['githubUid'] - 1));//Here is the file we are downloading, replace spaces with %20
+            $ch = curl_init('https://api.github.com/users?per_page=1&since=' . ($row['githubUid'] - 1));
             curl_setopt($ch, CURLOPT_TIMEOUT, 2);
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-//                sprintf('Authorization: token %s', $data['GITHUB_API_KEY']),
+                // Depending on the number of entries you'd want to include a
+                // GITHUB-API-TOKEN which you'd have to create first....
+                // sprintf('Authorization: token %s', YOUR_GITHUB_TOKEN),
                 'User-Agent: PHPMentoring-App',
             ));
             $info = curl_exec($ch); // get curl response

--- a/src/Mentoring/Controller/AuthController.php
+++ b/src/Mentoring/Controller/AuthController.php
@@ -38,6 +38,8 @@ class AuthController
 
             try {
                 $user = $app['user.manager']->fetchUserByGithubUid($userDetails->uid);
+                $user->setGithubName($userDetails->nickname);
+                $app['user.manager']->saveUser($user);
             } catch (UserNotFoundException $exception) {
                 $email = null;
                 foreach ($provider->getUserEmails($token) as $providerEmail) {

--- a/src/Mentoring/Controller/AuthController.php
+++ b/src/Mentoring/Controller/AuthController.php
@@ -52,6 +52,7 @@ class AuthController
                     'roles' => ['ROLE_USER'],
                     'name' => $userDetails->name,
                     'githubUid' => $userDetails->uid,
+                    'githubName' => $userDetails->nickname,
                 ]);
 
                 $app['user.manager']->saveUser($user);

--- a/src/Mentoring/User/User.php
+++ b/src/Mentoring/User/User.php
@@ -13,6 +13,7 @@ class User
     protected $timeCreated;
     protected $isEnabled = true;
     protected $githubUid = null;
+    protected $githubName = '';
     protected $isMentor = false;
     protected $isMentee = false;
     protected $profile = '';
@@ -44,6 +45,11 @@ class User
     public function getGithubUid()
     {
         return $this->githubUid;
+    }
+
+    public function getGithubName()
+    {
+        return $this->githubName;
     }
 
     public function getId()
@@ -99,6 +105,11 @@ class User
     public function setGithubUid($uid)
     {
         $this->githubUid = $uid;
+    }
+
+    public function setGithubName($name)
+    {
+        $this->githubName = $name;
     }
 
     public function setId($id)

--- a/src/Mentoring/User/UserHydrator.php
+++ b/src/Mentoring/User/UserHydrator.php
@@ -32,6 +32,7 @@ class UserHydrator
             'timeCreated' => $object->getTimeCreated(),
             'isEnabled' => $object->isEnabled(),
             'githubUid' => $object->getGithubUid(),
+            'githubName' => $object->getGithubName(),
             'isMentee' => $object->isMentee(),
             'isMentor' => $object->isMentor(),
             'profile' => $object->getProfile(),
@@ -90,6 +91,10 @@ class UserHydrator
 
         if (isset($data['githubUid'])) {
             $object->setGithubUid($data['githubUid']);
+        }
+
+        if (isset($data['githubName'])) {
+            $object->setGithubName($data['githubName']);
         }
 
         if (isset($data['timeCreated'])) {


### PR DESCRIPTION
This PR adds the github-nickname to the users dataset. 

That makes information retrieval via the GitHub-API much easier as currently only the Github-Internal ID is stored which isn't easy to use. If you want to get information about a specific user you can now simply call https://api.github.com/users/[githubName] to get all informations about the user.

Before you had to first call https://api.github.com/users/?per_page=1&since=[githubUid - 1] to get
the nickname and then call again the above users-endpoint to get the infos you might be interested in. 

Therefore you now only need one request instead of two.

This fixes Issue #53
