### PR TITLE
Remove absolute urls when possible

### DIFF
--- a/views/index/index.twig
+++ b/views/index/index.twig
@@ -26,7 +26,7 @@
     <section>
         <p>We communicate in various ways - from a google groups mailing list to an irc channel, wikis and example code directories on github, and our website. We also encourage face-to-face interaction - through user groups, meetups, conferences and other methods. We use technology to help connect people around the globe. Communication is the key to any good relationship.</p>
     </section>
-    <h2 id="vision-why"><a href="why-mentor.html">Why?</a></h2>
+    <h2 id="vision-why"><a href="{{ path('why') }}">Why?</a></h2>
     <section>
         <p>Mentoring is great for your career. It provides:</p>
         <ul>
@@ -39,18 +39,18 @@
             <li>Intangibles - humans want to do things that make us feel good, from giving back knowledge received as an apprentice to a new apprentice or just helping someone with a problem</li>
         </ul>
     </section>
-    <h2 id="vision-how"><a href="guidelines.html">How?</a></h2>
+    <h2 id="vision-how"><a href="{{ path('guidelines') }}">How?</a></h2>
     <section>
         <p>Want to become part of the vision?</p>
         <section>
             <ol>
-                <li>Read the <a href="{{ url('guidelines') }}#guidelines-charter">charter</a> and <a href="{{ url('guidelines') }}#guidelines-mentor">rules</a></li>
-                <li>Follow the <a href="{{ url('guidelines') }}#guidelines-started">checklist for new mentorship partners</a></li>
+                <li>Read the <a href="{{ path('guidelines') }}#guidelines-charter">charter</a> and <a href="{{ path('guidelines') }}#guidelines-mentor">rules</a></li>
+                <li>Follow the <a href="{{ path('guidelines') }}#guidelines-started">checklist for new mentorship partners</a></li>
                 <li>Connect with mentors or apprentices waiting to be matched</li>
-                <li>Follow the <a href="{{ url('guidelines') }}#guidelines-pairing">guidelines to match up</a></li>
+                <li>Follow the <a href="{{ path('guidelines') }}#guidelines-pairing">guidelines to match up</a></li>
                 <li>Talk to each other through IRC, e-mail, or the buit-in messaging system</li>
                 <li>Start mentoring!</li>
-                <li>Use <a href="{{ url('guidelines') }}#guidelines-resources">ongoing mentorship resources</a> to keep the relationship strong</li>
+                <li>Use <a href="{{ path('guidelines') }}#guidelines-resources">ongoing mentorship resources</a> to keep the relationship strong</li>
                 <li>Further Questions? Check out our <a href="https://github.com/phpmentoring/phpmentoring.github.com/wiki/HOWTO">How-To wiki</a></li>
             </ol>
         </section>

--- a/views/layouts/default.twig
+++ b/views/layouts/default.twig
@@ -41,25 +41,25 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="{{ url('index') }}">PHP Mentoring</a>
+            <a class="navbar-brand" href="{{ path('index') }}">PHP Mentoring</a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-                <li><a href="{{ url('guidelines') }}">Guidelines</a></li>
-                <li><a href="{{ url('why') }}">Why Mentoring</a></li>
-                <li><a href="{{ url('mentors') }}">Search Mentors</a></li>
-                <!-- <li><a href="{{ url('apprentices') }}">Search Apprentices</a></li> -->
+                <li><a href="{{ path('guidelines') }}">Guidelines</a></li>
+                <li><a href="{{ path('why') }}">Why Mentoring</a></li>
+                <li><a href="{{ path('mentors') }}">Search Mentors</a></li>
+                <!-- <li><a href="{{ path('apprentices') }}">Search Apprentices</a></li> -->
                 <li><a href="http://webchat.freenode.net/?channels=phpmentoring&uio=MTE9MjI2dd">Join us on IRC</a></li>
             </ul>
 
             <ul class="nav navbar-nav navbar-right">
             {% if app.session.get('user') %}
-                <li><a href="{{ url('account.profile') }}">My Profile</a></li>
+                <li><a href="{{ path('account.profile') }}">My Profile</a></li>
                 {% set unread = unread_messages(app.session.get('user')) %}
-                <li><a href="{{ url('conversation.index') }}">Inbox{% if unread > 0 %} ({{ unread }}){% endif %}</a></li>
-                <li><a href="{{ url('auth.logout') }}">Logout</a></li>
+                <li><a href="{{ path('conversation.index') }}">Inbox{% if unread > 0 %} ({{ unread }}){% endif %}</a></li>
+                <li><a href="{{ path('auth.logout') }}">Logout</a></li>
             {% else %}
-                <li><a href="{{ url('auth.login') }}">Login</a></li>
+                <li><a href="{{ path('auth.login') }}">Login</a></li>
             {% endif %}
             </ul>
 


### PR DESCRIPTION
Since SSL has been activated on the website, the home page is https by default. Problem comes when browsing the website using links, as most links were using the twig `url` helper, users get redirected to the http version (absolute url and https not forced in routing config).

By using the `path` helper in Twig, we can generate relative urls (relative to the root I guess), and therefore stay on whatever protocol the user choose.
- fix two links on the homepage.
