### PR TITLE
Adds explanatory text when user is viewing a mentor but not logged in…

### DIFF
--- a/views/index/profile.twig
+++ b/views/index/profile.twig
@@ -65,6 +65,12 @@
     </div>
     {{ form_end(message_form) }}
     {% endif %}
+
+    {% if not app.session.get('user') %}
+        <p>
+            If you would like to contact {{ viewing_user.name }} please <a href="{{ path('auth.login') }}">Login</a>.
+        </p>
+    {% endif %}
     </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Resolves #68

Open to suggestions on text. Currently set to `If you would like to contact {{ viewing_user.name }} please <a href="{{ path('auth.login') }}">Login</a>.`
