### PR TITLE
update default DB values in .env.example to scotchbox VM defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 DB_DRIVER=pdo_mysql
 DB_HOSTNAME=localhost
-DB_DBNAME=mentoring
+DB_DBNAME=scotchbox
 DB_USERNAME=root
-DB_PASSWORD=vagrant
+DB_PASSWORD=root
 
 MAIL_HOST=localhost
 MAIL_PORT=25


### PR DESCRIPTION
When installing the app via the Vagrant route, the default `.env.example` DB values are not valid. In addition, they are also not consistent with the example given for a local install. 

This PR makes the default `.env.example` values work inside the VM.