### PR TITLE
Update the navbar with new chat links

### DIFF
--- a/views/layouts/default.twig
+++ b/views/layouts/default.twig
@@ -47,9 +47,16 @@
             <ul class="nav navbar-nav">
                 <li><a href="{{ path('guidelines') }}">Guidelines</a></li>
                 <li><a href="{{ path('why') }}">Why Mentoring</a></li>
-                <li><a href="{{ path('mentors') }}">Search Mentors</a></li>
+                <!-- <li><a href="{{ path('mentors') }}">Search Mentors</a></li> -->
                 <!-- <li><a href="{{ path('apprentices') }}">Search Apprentices</a></li> -->
-                <li><a href="http://webchat.freenode.net/?channels=phpmentoring&uio=MTE9MjI2dd">Join us on IRC</a></li>
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Join us on… <span class="caret"></span></a>
+                    <ul class="dropdown-menu">
+                        <li><a href="https://discord.gg/eMtPMFaMWP" target="_blank">Discord</a></li>
+                        <li><a href="https://web.libera.chat/#phpmentoring" target="_blank">IRC</a></li>
+                        <li><a href="https://matrix.to/#/#phpmentoring:matrix.org" target="_blank">Matrix</a></li>
+                    </ul>
+                </li>
             </ul>
 
             <ul class="nav navbar-nav navbar-right">
@@ -59,7 +66,7 @@
                 <li><a href="{{ path('conversation.index') }}">Inbox{% if unread > 0 %} ({{ unread }}){% endif %}</a></li>
                 <li><a href="{{ path('auth.logout') }}">Logout</a></li>
             {% else %}
-                <li><a href="{{ path('auth.login') }}">Login</a></li>
+                <!-- <li><a href="{{ path('auth.login') }}">Login</a></li> -->
             {% endif %}
             </ul>
 


### PR DESCRIPTION
I've updated the navbar to include a drop-down menu with chat links to IRC (#phpmentoring on Libera), Discord (#phpmentoring on PHP Community), and Matrix (#phpmentoring:matrix.org). All of these channels are bridged together, so joining one allows you to talk to users on the other networks.

<img width="571" alt="Screen Shot 2022-05-03 at 12 31 43" src="https://user-images.githubusercontent.com/42941/166507383-6de11e26-0a73-4003-9edc-cbe585ce740d.png">